### PR TITLE
Prevent the rejection of UIDs in the archetype section

### DIFF
--- a/oship/src/oship/openehr/adl_1_4.py
+++ b/oship/src/oship/openehr/adl_1_4.py
@@ -85,7 +85,7 @@ if inline_validating:
     assert '1.2..3.4' == (number + '..' + number)
 
 uri = Combine(Word(alphas) + '://' + CharsNotIn(" >"))
-val = real | integer | attr_identifier
+val = Regex(r"[^;\)\r\n]+")
 valueDef = Forward()
 valueDef << Group( key + EQ + LT +
         Optional( Dict(OneOrMore( valueDef )) |
@@ -240,7 +240,7 @@ SPECIALIZE = CaselessKeyword("specialize") | CaselessKeyword("specialise")
 # ADL file sections:
 versionNum = delimitedList(Word(nums),'.',combine=True)
 archetypeSection = ARCHETYPE + LPAR + \
-                    Dict(delimitedList(Group(key + EQ + (versionNum | val) |
+                    Dict(delimitedList(Group(key + EQ + val |
                                              "controlled" | "uncontrolled"),";")) + \
                     RPAR + fileref("name_version")
 specializeSection = SPECIALIZE + fileref("name_version")


### PR DESCRIPTION
The attributes in the archetype section could be numbers or alphanumericals, but not UIDs.

In order to fix it, I changed the `val` parser rule to accept anything that is not a `;`. a `)` or a line break.

Closes #1 